### PR TITLE
Use nvidia-persistenced instead of legacy persistence mode

### DIFF
--- a/tasks/cuda_init.yml
+++ b/tasks/cuda_init.yml
@@ -39,6 +39,23 @@
     - ansible_os_family == 'RedHat'
     - ansible_distribution_major_version|int >= 7
 
+- name: Enable nvidia-persistenced systemd service
+  service:
+    name: nvidia-persistenced
+    enabled: yes
+  when:
+    - ansible_connection != 'chroot'
+    - cuda_init_persistence_mode | bool
+
+# Due to ansible bug 21026, cannot use service module on RHEL 7
+- name: enable the nvidia-persistenced systemd service in chroots
+  command: systemctl enable nvidia-persistenced
+  when:
+    - ansible_connection == 'chroot'
+    - ansible_os_family == 'RedHat'
+    - ansible_distribution_major_version|int >= 7
+    - cuda_init_persistence_mode | bool
+
 - name: check if cuda_gpu_name0 ( /dev/nvidia0 ) exists
   stat:
     path: "{{ cuda_gpu_name0 }}"
@@ -55,5 +72,15 @@
     - reg_cuda_gpu_name0.stat.exists is defined
     - reg_cuda_gpu_name0.stat.exists == False
     - cuda_init_restart_service|bool
+
+- name: Start nvidia-persistenced if GPU found and not chroot
+  service:
+    name: nvidia-persistenced
+    state: started
+  when:
+    - ansible_connection != 'chroot'
+    - cuda_init_persistence_mode | bool
+    - reg_cuda_gpu_name0.stat.exists is defined
+    - reg_cuda_gpu_name0.stat.exists == True
 
 # vim:ft=ansible:

--- a/templates/cuda_init.sh.j2
+++ b/templates/cuda_init.sh.j2
@@ -5,5 +5,4 @@ if [ ! -f "/usr/bin/nvidia-smi" ]; then
         logger -s -t nvidia-smi "Script $0 could not find /usr/bin/nvidia-smi"
 else
         /usr/bin/nvidia-smi --compute-mode={{ cuda_init_compute_mode }}
-        /usr/bin/nvidia-smi --persistence-mode={{ cuda_init_persistence_mode }}
 fi


### PR DESCRIPTION
The persistence mode of the Nvidia driver has been deprecated, and
enabling it triggers a warning in dmesg:

NVRM: Persistence mode is deprecated and will be removed in a future release. Please use nvidia-persistenced instead.

See also https://docs.nvidia.com/deploy/driver-persistence/index.html

Thus, change to instead enable and start the nvidia-persistenced
service. This should fix
https://github.com/CSCfi/ansible-role-cuda/issues/19