### PR TITLE
number 3 is depricated.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ cuda_packages:
 cuda_restart_node_on_install: True
 cuda_init: True
 cuda_init_restart_service: True
-cuda_init_compute_mode: 3
+cuda_init_compute_mode: 0
 cuda_init_persistence_mode: 1
 cuda_gpu_name0: "/dev/nvidia0"
 cuda_bash_profile: True


### PR DESCRIPTION
Also, in slurm v18+ croups access limitiation to gpus work by default. Thus default mode would be better default since it also supports multi-GPU training. Depricated number 3 refers nowadays to 1 (exclusive_process).

