### PR TITLE
Add functionality for enabling nvidia performance counters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,6 @@ cuda_bash_cuda_root: "/usr/local/cuda"
 cuda_bash_cuda_inc_dir: "/usr/local/cuda/bin"
 cuda_bash_cpath: "/usr/local/cuda/include"
 
+cuda_enable_perf_counters: False
+
 # vim:ft=ansible:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,13 @@
   - include_tasks: cuda_init.yml
     when: cuda_init
 
+  - name: Enable performance counters for all users via modprobe
+    template:
+      src: nvidia.conf.j2
+      dest: /etc/modprobe.d/nvidia.conf
+      mode: 0644
+    when: cuda_enable_perf_counters
+
   # This is here because if we in the same playbook try to start slurmd without
   # having run the cuda_init.sh script then slurmd doesn't start and the play fails.
   # todo: reload nvidia modules/etc instead of restart

--- a/templates/nvidia.conf.j2
+++ b/templates/nvidia.conf.j2
@@ -1,0 +1,1 @@
+options nvidia "NVreg_RestrictProfilingToAdminUsers=0"


### PR DESCRIPTION
This PR allows admins to enable NVIDIA's performance counters on the GPU nodes. Enabling is done as specified in [NVIDIA's manual](https://developer.nvidia.com/nvidia-development-tools-solutions-ERR_NVGPUCTRPERM-permission-issue-performance-counters).

The counters are by default limited to admins due to a [security issue](https://nvidia.custhelp.com/app/answers/detail/a_id/4738), which might allow for users to snoop on data housed on the GPU in a multi-user environment.

This is hopefully somewhat mitigated by the SLURM's cgroups and the `pam_slurm_adopt.so`-module, which force each job and ssh session to cgroup that is limited to a single GPU. Thus every GPU should have access to only the GPU it has reserved.

New flags:
- `cuda_enable_perf_counters` (default: False): Enables performance counters after next reboot.